### PR TITLE
Remove the < PHP 8 version contraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - '7.2'
   - '7.3'
   - '7.4'
+  - '8.0'
 
 install:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "Codeception\\ProgressReporter\\Tests\\": "tests/_support"
   },
   "require": {
-    "php": ">=5.6.0",
+    "php": ">=5.6.0 <8.1",
     "codeception/codeception": ">=2.3 <5.0",
     "symfony/console": ">=2.7 <6.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "Codeception\\ProgressReporter\\Tests\\": "tests/_support"
   },
   "require": {
-    "php": ">=5.6.0 <8.0",
+    "php": ">=5.6.0",
     "codeception/codeception": ">=2.3 <5.0",
     "symfony/console": ">=2.7 <6.0"
   },


### PR DESCRIPTION
When installing it through composer on PHP 8, I get an error as you can see in #22. But when I install it on PHP 7 and let the tests run on PHP 8, then all works. Looks like the project is PHP 8 compatible, so we can remove the constraint from the composer file.