### PR TITLE
Modernize for 5.0.0 (Codeception 5, PHP 8.1+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - '7.0'
-          - '7.1'
-          - '7.2'
-          - '7.3'
-          - '7.4'
-          - '8.0'
           - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
 
     name: PHP ${{ matrix.php-version }}
 
@@ -33,6 +30,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none
+          ini-values: register_argc_argv=On, memory_limit=512M
           tools: composer:v2
 
       - name: Get Composer cache directory
@@ -50,8 +48,29 @@ jobs:
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction
 
-      - name: Generate tests
+      - name: Generate stub tests
         run: sh ./maketests.sh
 
       - name: Run tests
         run: php vendor/bin/codecept run
+
+  static-analysis:
+    runs-on: ubuntu-latest
+    name: Static analysis
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction
+
+      - name: Run PHPStan
+        run: php vendor/bin/phpstan analyse --no-progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
 
     name: PHP ${{ matrix.php-version }}
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 
 ![preview](preview.svg)
 
+## Requirements
+
+| Package version | PHP        | Codeception |
+|-----------------|------------|-------------|
+| `^5.0`          | `>= 8.1`   | `^5.0`      |
+| `^4.0`          | `>= 5.6`   | `>= 2.3`    |
+
 ## How to install
 ```bash
 composer require codeception/codeception-progress-reporter

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
     "Codeception\\ProgressReporter\\Tests\\": "tests/_support"
   },
   "require": {
-    "php": ">=5.6.0",
-    "codeception/codeception": ">=2.3",
-    "symfony/console": ">=2.7"
+    "php": ">=8.1",
+    "codeception/codeception": "^5.0",
+    "symfony/console": "^6.0 || ^7.0"
   },
   "require-dev": {
-    "codeception/module-asserts": "^1.1",
-    "behat/gherkin": "<4.9"
+    "codeception/module-asserts": "^3.0",
+    "phpstan/phpstan": "^2.0"
   }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,4 @@
+parameters:
+    level: 6
+    paths:
+        - src

--- a/src/ProgressReporter.php
+++ b/src/ProgressReporter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\ProgressReporter;
 
 use Codeception\Event\FailEvent;
@@ -10,51 +12,50 @@ use Codeception\Extension;
 use Codeception\Subscriber\Console;
 use Symfony\Component\Console\Helper\ProgressBar;
 
+use function count;
+use function max;
+use function pathinfo;
+
+use const PATHINFO_FILENAME;
+
 /**
- * Class ProgressReporter
+ * Codeception extension that replaces the default reporter output with a
+ * single terminal progress bar summarising the current suite run.
  */
 class ProgressReporter extends Extension
 {
     /**
-     * We are listening for events
+     * Events this extension subscribes to.
      *
-     * @var array
+     * @var array<string, string>
      */
-    public static $events = [];
+    public static array $events = [];
 
     /**
-     * Standard reporter for printing fails
-     *
-     * @var Console
+     * Standard reporter reused for printing failures at the end of the run.
      */
-    public $standardReporter;
+    public ?Console $standardReporter = null;
+
+    protected ?ProgressBar $progress = null;
+
+    protected Status $status;
 
     /**
-     * Progress bar
-     *
-     * @var ProgressBar
+     * Number of failures printed so far (used to number the fail report).
      */
-    protected $progress;
+    private int $failNumber = 0;
 
-    /**
-     * Status (counter)
-     *
-     * @var Status
-     */
-    protected $status;
-
-    /**
-     * Setup
-     */
-    public function _initialize()
+    public function _initialize(): void
     {
         if ($this->options['steps'] || $this->options['debug']) {
-            // Don't show progress bar when --steps or --debug option is provided
+            // Don't show the progress bar when --steps or --debug is provided.
             $this->unsubscribeFromEvents();
+
             return;
         }
 
         $this->subscribeToEvents();
+
         $format = '';
         if (!$this->options['silent']) {
             $format = "\nCurrent suite: <options=bold>%suite%</>\n" .
@@ -63,16 +64,17 @@ class ProgressReporter extends Extension
                 "<fg=cyan>[%bar%]</>\n%current%/%max% %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%\n";
         }
 
-        $this->_reconfigure(['settings' => ['silent' => true]]); // turn off printing for everything else
+        // Turn off default printing for everything else.
+        $this->_reconfigure(['settings' => ['silent' => true]]);
         $this->standardReporter = new Console($this->options);
         ProgressBar::setFormatDefinition('custom', $format);
         $this->status = new Status();
     }
 
     /**
-     * Subscribe to all events
+     * Subscribe to all events.
      */
-    private function subscribeToEvents()
+    private function subscribeToEvents(): void
     {
         self::$events = [
             Events::SUITE_BEFORE => 'beforeSuite',
@@ -87,99 +89,92 @@ class ProgressReporter extends Extension
     }
 
     /**
-     * Unsubscribe from all events
+     * Unsubscribe from all events.
      */
-    private function unsubscribeFromEvents()
+    private function unsubscribeFromEvents(): void
     {
         self::$events = [];
     }
 
     /**
-     * Setup progress bar
-     *
-     * @param SuiteEvent $event
+     * Set up the progress bar for the suite.
      */
-    public function beforeSuite(SuiteEvent $event)
+    public function beforeSuite(SuiteEvent $event): void
     {
         $this->status = new Status();
+        $this->failNumber = 0;
 
-        $count = $event->getSuite()->count(true);
+        $suite = $event->getSuite();
+        $count = max(1, count($suite->getTests()));
+
         $this->progress = new ProgressBar($this->output, $count);
         $this->progress->setFormat('custom');
         $this->progress->setBarWidth($count);
-        $this->progress->setRedrawFrequency($count / 100);
+        $this->progress->setRedrawFrequency((int) max(1, $count / 100));
 
         $this->progress->setMessage('none', 'file');
-        $this->progress->setMessage($event->getSuite()->getBaseName(), 'suite');
-        $this->progress->setMessage($this->status->getSuccess(), 'success');
-        $this->progress->setMessage($this->status->getFails(), 'fails');
-        $this->progress->setMessage($this->status->getErrors(), 'errors');
+        $this->progress->setMessage($suite->getBaseName(), 'suite');
+        $this->updateCounters();
 
         $this->progress->start();
     }
 
     /**
-     * After suite
+     * Redraw the progress bar once the suite has finished.
      */
-    public function afterSuite()
+    public function afterSuite(): void
     {
-        $this->progress->display();
+        $this->progress?->display();
     }
 
     /**
-     * After test
+     * Advance the progress bar after each test.
      */
-    public function afterTest()
+    public function afterTest(): void
     {
-        $this->progress->advance();
-        $this->progress->setMessage($this->status->getSuccess(), 'success');
-        $this->progress->setMessage($this->status->getFails(), 'fails');
-        $this->progress->setMessage($this->status->getErrors(), 'errors');
+        $this->progress?->advance();
+        $this->updateCounters();
     }
 
     /**
-     * Before test
-     *
-     * @param TestEvent $event
+     * Display the name of the test that is about to run.
      */
-    public function beforeTest(TestEvent $event)
+    public function beforeTest(TestEvent $event): void
     {
-        $message = $event->getTest()->getMetadata()->getFilename();
-        $this->progress->setMessage(pathinfo($message, PATHINFO_FILENAME), 'file');
-    }
-
-
-    /**
-     * Print failed tests
-     *
-     * @param FailEvent $event
-     */
-    public function printFailed(FailEvent $event)
-    {
-        $this->standardReporter->printFail($event);
+        $filename = $event->getTest()->getMetadata()->getFilename();
+        $this->progress?->setMessage(pathinfo($filename, PATHINFO_FILENAME), 'file');
     }
 
     /**
-     * Success event
+     * Print failed tests using the standard reporter.
      */
-    public function success()
+    public function printFailed(FailEvent $event): void
+    {
+        $this->standardReporter?->printFail($event, ++$this->failNumber);
+    }
+
+    public function success(): void
     {
         $this->status->incSuccess();
     }
 
-    /**
-     * Error event
-     */
-    public function error()
+    public function error(): void
     {
         $this->status->incErrors();
     }
 
-    /**
-     * Fail event
-     */
-    public function fail()
+    public function fail(): void
     {
         $this->status->incFails();
+    }
+
+    /**
+     * Push the current status counters into the progress bar messages.
+     */
+    private function updateCounters(): void
+    {
+        $this->progress?->setMessage((string) $this->status->getSuccess(), 'success');
+        $this->progress?->setMessage((string) $this->status->getFails(), 'fails');
+        $this->progress?->setMessage((string) $this->status->getErrors(), 'errors');
     }
 }

--- a/src/Status.php
+++ b/src/Status.php
@@ -1,83 +1,46 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Codeception\ProgressReporter;
 
 /**
- * Class Status
+ * Mutable counter that tracks the outcome of tests within a suite run.
  */
-class Status
+final class Status
 {
-    /**
-     * Fails count
-     *
-     * @var int
-     */
-    private $fails = 0;
+    private int $fails = 0;
 
-    /**
-     * Success count
-     *
-     * @var int
-     */
-    private $success = 0;
+    private int $success = 0;
 
-    /**
-     * Errors count
-     *
-     * @var int
-     */
-    private $errors = 0;
+    private int $errors = 0;
 
-    /**
-     * Get fails count
-     *
-     * @return int
-     */
-    public function getFails()
+    public function getFails(): int
     {
         return $this->fails;
     }
 
-    /**
-     * Get success count
-     *
-     * @return int
-     */
-    public function getSuccess()
+    public function getSuccess(): int
     {
         return $this->success;
     }
 
-    /**
-     * Get errors count
-     *
-     * @return int
-     */
-    public function getErrors()
+    public function getErrors(): int
     {
         return $this->errors;
     }
 
-    /**
-     * Increment success
-     */
-    public function incSuccess()
+    public function incSuccess(): void
     {
         $this->success++;
     }
 
-    /**
-     * Increment errors
-     */
-    public function incErrors()
+    public function incErrors(): void
     {
         $this->errors++;
     }
 
-    /**
-     * Increment fails
-     */
-    public function incFails()
+    public function incFails(): void
     {
         $this->fails++;
     }

--- a/tests/unit/StatusTest.php
+++ b/tests/unit/StatusTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\ProgressReporter\Tests\Unit;
+
+use Codeception\ProgressReporter\Status;
+use Codeception\ProgressReporter\Tests\UnitTester;
+use Codeception\Test\Unit;
+
+final class StatusTest extends Unit
+{
+    protected UnitTester $tester;
+
+    private Status $status;
+
+    protected function _before(): void
+    {
+        $this->status = new Status();
+    }
+
+    public function testCountersStartAtZero(): void
+    {
+        $this->assertSame(0, $this->status->getSuccess());
+        $this->assertSame(0, $this->status->getErrors());
+        $this->assertSame(0, $this->status->getFails());
+    }
+
+    public function testIncSuccess(): void
+    {
+        $this->status->incSuccess();
+        $this->status->incSuccess();
+
+        $this->assertSame(2, $this->status->getSuccess());
+        $this->assertSame(0, $this->status->getErrors());
+        $this->assertSame(0, $this->status->getFails());
+    }
+
+    public function testIncErrors(): void
+    {
+        $this->status->incErrors();
+
+        $this->assertSame(1, $this->status->getErrors());
+        $this->assertSame(0, $this->status->getSuccess());
+        $this->assertSame(0, $this->status->getFails());
+    }
+
+    public function testIncFails(): void
+    {
+        $this->status->incFails();
+        $this->status->incFails();
+        $this->status->incFails();
+
+        $this->assertSame(3, $this->status->getFails());
+        $this->assertSame(0, $this->status->getSuccess());
+        $this->assertSame(0, $this->status->getErrors());
+    }
+
+    public function testCountersAreIndependent(): void
+    {
+        $this->status->incSuccess();
+        $this->status->incErrors();
+        $this->status->incFails();
+
+        $this->assertSame(1, $this->status->getSuccess());
+        $this->assertSame(1, $this->status->getErrors());
+        $this->assertSame(1, $this->status->getFails());
+    }
+}


### PR DESCRIPTION
## Summary

Clean-break **5.0.0** that tracks **Codeception 5** only.

**BREAKING**: drops Codeception 4 and PHP < 8.1 support.

### Dependencies
- `php >= 8.1`
- `codeception/codeception ^5.0`
- `symfony/console ^6.0 || ^7.0`
- dev: `codeception/module-asserts ^3.0`, `phpstan/phpstan ^2.0`

### Codeception 5 API adaptation
The v4 code no longer runs under v5 — the following had to change:
- `Extension` lifecycle/handler methods now declare `: void` return types.
- `Console::printFail()` now requires a second `int $eventNumber` argument (we number failures as they print).
- Suite test count is obtained via `Suite::getTests()`.

### Code modernization
- `declare(strict_types=1)`, typed properties, param/return types.
- Null-safe handling of the progress bar / standard reporter.
- `Status` is now a `final` typed counter.

### Quality
- Added real unit tests for `Status`.
- Added PHPStan (level 6) + `phpstan.neon.dist`.
- CI matrix updated to PHP **8.1–8.4** and a dedicated **static-analysis** job.

### Docs
- README now documents the version / PHP / Codeception support matrix.

### Verification
- `codecept run` — full suite green under Codeception 5.3.5 (unit + api).
- New `StatusTest` — 5 tests, 15 assertions pass.
- PHPStan level 6 — no errors.
- Failure/error path exercised with a deliberately failing test (printFail works with the new signature).