### PR TITLE
docs: add Packagist badges and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,26 @@
 # Codeception Progress Reporter
+
 [![CI](https://github.com/fr05t1k/codeception-progress-reporter/actions/workflows/ci.yml/badge.svg)](https://github.com/fr05t1k/codeception-progress-reporter/actions/workflows/ci.yml)
+[![Latest Stable Version](https://poser.pugx.org/codeception/codeception-progress-reporter/v)](https://packagist.org/packages/codeception/codeception-progress-reporter)
+[![Total Downloads](https://poser.pugx.org/codeception/codeception-progress-reporter/downloads)](https://packagist.org/packages/codeception/codeception-progress-reporter)
+[![PHP Version Require](https://poser.pugx.org/codeception/codeception-progress-reporter/require/php)](https://packagist.org/packages/codeception/codeception-progress-reporter)
+[![License](https://poser.pugx.org/codeception/codeception-progress-reporter/license)](https://packagist.org/packages/codeception/codeception-progress-reporter)
+
+A [Codeception](https://codeception.com/) extension that replaces the default
+test output with a single, live terminal **progress bar**. It shows the current
+suite and test, running counts of successes/errors/fails, elapsed and estimated
+time, and memory usage — handy for large suites where the default output scrolls
+off the screen.
 
 ![preview](preview.svg)
+
+## Features
+
+- Live progress bar with success / error / fail counters.
+- Current suite and test name displayed as the run advances.
+- Elapsed vs. estimated time and peak memory usage.
+- Failures are still printed in full at the end of the run.
+- Automatically disables itself when running with `--steps` or `--debug`.
 
 ## Requirements
 
@@ -10,19 +29,39 @@
 | `^5.0`          | `>= 8.1`   | `^5.0`      |
 | `^4.0`          | `>= 5.6`   | `>= 2.3`    |
 
-## How to install
+## Installation
+
 ```bash
-composer require codeception/codeception-progress-reporter
+composer require --dev codeception/codeception-progress-reporter
 ```
-## How to enable:
-Place it in your `codeception.yml`
+
+## Usage
+
+Enable it globally in your `codeception.yml`:
+
 ```yaml
 extensions:
     enabled:
         - Codeception\ProgressReporter\ProgressReporter
 ```
 
-Or specify manually
+Or enable it for a single run:
+
 ```bash
-codecept run --ext Codeception\\ProgressReporter\\ProgressReporter
+codecept run --ext "Codeception\\ProgressReporter\\ProgressReporter"
 ```
+
+## Contributing
+
+Issues and pull requests are welcome. Please make sure the test suite and static
+analysis pass before opening a PR:
+
+```bash
+composer install
+vendor/bin/codecept run
+vendor/bin/phpstan analyse
+```
+
+## License
+
+Released under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

- Add Packagist badges: latest stable version, total downloads, required PHP version, and license.
- Add a short description of what the extension does.
- Add a **Features** section.
- Clarify install as a dev dependency (`--dev`) and add a **Usage** / **Contributing** / **License** sections.

Docs-only change.