### PR TITLE
Validate reporter output (e2e) + fix missing failure report on Codeception 5

### DIFF
--- a/.github/workflows/pr-demo.yml
+++ b/.github/workflows/pr-demo.yml
@@ -1,0 +1,111 @@
+name: PR demo
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Regenerates the animated progress-bar demo and posts it as a PR comment so the
+# reporter output can be verified visually. Skipped for fork PRs, which only get
+# a read-only token and cannot push the asset or comment.
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-demo-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  demo:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          ini-values: register_argc_argv=On, memory_limit=512M
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction
+
+      - name: Install rendering tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends fonts-dejavu-core
+          curl -sSL -o /usr/local/bin/agg \
+            https://github.com/asciinema/agg/releases/download/v1.9.0/agg-x86_64-unknown-linux-musl
+          chmod +x /usr/local/bin/agg
+          agg --version
+
+      - name: Record demo GIF
+        env:
+          DEMO_TESTS: '20'
+          DEMO_DELAY: '0.08'
+        run: ./scripts/record-pr-demo.sh demo.gif
+
+      - name: Publish GIF to demo-assets branch
+        id: publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          file="pr-${PR_NUMBER}.gif"
+          cp demo.gif "/tmp/${file}"
+
+          work="$(mktemp -d)"
+          repo_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          if git clone --quiet --branch demo-assets --single-branch "${repo_url}" "${work}" 2>/dev/null; then
+            cd "${work}"
+          else
+            git clone --quiet "${repo_url}" "${work}"
+            cd "${work}"
+            git checkout --orphan demo-assets
+            git rm -rfq . 2>/dev/null || true
+          fi
+
+          cp "/tmp/${file}" "./${file}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "${file}"
+          if git diff --cached --quiet; then
+            echo "GIF unchanged; reusing existing asset."
+          else
+            git commit -qm "demo: update ${file} for PR #${PR_NUMBER} [skip ci]"
+            git push -q origin demo-assets
+          fi
+
+          sha="$(git rev-parse HEAD)"
+          echo "url=https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${sha}/${file}" >> "$GITHUB_OUTPUT"
+
+      - name: Find existing demo comment
+        uses: peter-evans/find-comment@v3
+        id: find
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- pr-demo-comment -->'
+
+      - name: Create or update demo comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- pr-demo-comment -->
+            ### 🎬 Progress reporter demo
+
+            A live recording of the extension running a suite (with one failing and
+            one erroring test) so the output can be verified visually.
+
+            ![progress reporter demo](${{ steps.publish.outputs.url }})
+
+            <sub>Regenerated automatically from ${{ github.event.pull_request.head.sha }}.</sub>

--- a/scripts/record-pr-demo.sh
+++ b/scripts/record-pr-demo.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Records the REAL Codeception progress bar (src/ProgressReporter.php) into an
+# animated GIF used for visual verification on pull requests.
+#
+# Unlike scripts/record-demo.sh (which produces the README's happy-path SVG),
+# this run deliberately includes a failing and an erroring test so the GIF also
+# shows the end-of-run failure report the reporter delegates to Codeception.
+#
+# GitHub does not render SVG inside PR/issue comments, so we emit a GIF here.
+#
+# Requirements:
+#   - php (cli) + composer
+#   - python3            (scripts/capture-cast.py, pty capture)
+#   - agg                (asciinema GIF generator; path overridable via $AGG)
+#
+# Usage:
+#   ./scripts/record-pr-demo.sh [output.gif]
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+OUT="${1:-${DEMO_OUT:-demo.gif}}"
+PASS_TESTS="${DEMO_TESTS:-18}"
+DELAY="${DEMO_DELAY:-0.05}"
+COLS="${DEMO_COLS:-100}"
+ROWS="${DEMO_ROWS:-20}"
+AGG="${AGG:-agg}"
+
+PHP="php -d register_argc_argv=On -d memory_limit=512M"
+
+command -v python3 >/dev/null 2>&1 || { echo "error: python3 not found" >&2; exit 1; }
+command -v "${AGG}" >/dev/null 2>&1 || { echo "error: agg not found (set \$AGG)" >&2; exit 1; }
+
+echo "==> Generating ${PASS_TESTS} passing demo tests (+1 fail, +1 error)"
+rm -rf tests/unit/Stub
+mkdir -p tests/unit/Stub
+
+for i in $(seq 1 "${PASS_TESTS}"); do
+  $PHP vendor/bin/codecept g:test unit "Stub/Demo${i}" >/dev/null
+  file="tests/unit/Stub/Demo${i}Test.php"
+  perl -0pi -e "s/public function testSomeFeature\(\)\s*\{/public function testSomeFeature()\n    {\n        usleep((int)(${DELAY} * 1000000));/" "$file"
+done
+
+# A failing and an erroring test so the GIF shows the failure report too.
+cat > tests/unit/Stub/DemoFailTest.php <<'PHP'
+<?php
+
+namespace Codeception\ProgressReporter\Tests\Unit\Stub;
+
+use Codeception\Test\Unit;
+
+class DemoFailTest extends Unit
+{
+    public function testFailingExample(): void
+    {
+        usleep(50000);
+        $this->assertSame('expected', 'actual', 'demo failure');
+    }
+}
+PHP
+
+cat > tests/unit/Stub/DemoErrorTest.php <<'PHP'
+<?php
+
+namespace Codeception\ProgressReporter\Tests\Unit\Stub;
+
+use Codeception\Test\Unit;
+
+class DemoErrorTest extends Unit
+{
+    public function testErroringExample(): void
+    {
+        usleep(50000);
+        throw new \RuntimeException('demo error');
+    }
+}
+PHP
+
+CAST="$(mktemp --suffix=.cast)"
+echo "==> Recording real progress bar (${COLS}x${ROWS})"
+# The pty makes Codeception treat the output as a real color terminal, so the
+# progress bar overwrites in place (as a user sees it) instead of stacking.
+# codecept exits non-zero because of the demo failures; that is expected.
+python3 scripts/capture-cast.py "${CAST}" "${COLS}" "${ROWS}" -- \
+  ${PHP} vendor/bin/codecept run unit Stub || true
+
+echo "==> Rendering GIF -> ${OUT}"
+"${AGG}" --theme monokai --font-size 16 --speed 1 "${CAST}" "${OUT}"
+rm -f "${CAST}"
+
+echo "==> Cleaning up demo tests"
+rm -rf tests/unit/Stub
+
+echo "==> Done: ${OUT}"

--- a/src/ProgressReporter.php
+++ b/src/ProgressReporter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Codeception\ProgressReporter;
 
-use Codeception\Event\FailEvent;
+use Codeception\Event\PrintResultEvent;
 use Codeception\Event\SuiteEvent;
 use Codeception\Event\TestEvent;
 use Codeception\Events;
@@ -39,11 +39,6 @@ class ProgressReporter extends Extension
     protected ?ProgressBar $progress = null;
 
     protected Status $status;
-
-    /**
-     * Number of failures printed so far (used to number the fail report).
-     */
-    private int $failNumber = 0;
 
     public function _initialize(): void
     {
@@ -81,7 +76,7 @@ class ProgressReporter extends Extension
             Events::SUITE_AFTER => 'afterSuite',
             Events::TEST_BEFORE => 'beforeTest',
             Events::TEST_AFTER => 'afterTest',
-            Events::TEST_FAIL_PRINT => 'printFailed',
+            Events::RESULT_PRINT_AFTER => 'printResult',
             Events::TEST_SUCCESS => 'success',
             Events::TEST_ERROR => 'error',
             Events::TEST_FAIL => 'fail',
@@ -102,7 +97,6 @@ class ProgressReporter extends Extension
     public function beforeSuite(SuiteEvent $event): void
     {
         $this->status = new Status();
-        $this->failNumber = 0;
 
         $suite = $event->getSuite();
         $count = max(1, count($suite->getTests()));
@@ -146,11 +140,16 @@ class ProgressReporter extends Extension
     }
 
     /**
-     * Print failed tests using the standard reporter.
+     * Print the full error/failure report once the run has finished.
+     *
+     * In Codeception 5 the built-in Console reporter is what renders the
+     * end-of-run defect list, but we silence it so only the progress bar is
+     * shown during the run. We therefore delegate the final report to a
+     * dedicated Console instance here.
      */
-    public function printFailed(FailEvent $event): void
+    public function printResult(PrintResultEvent $event): void
     {
-        $this->standardReporter?->printFail($event, ++$this->failNumber);
+        $this->standardReporter?->afterResult($event);
     }
 
     public function success(): void

--- a/tests/_data/reporter-fixture/.gitignore
+++ b/tests/_data/reporter-fixture/.gitignore
@@ -1,0 +1,3 @@
+tests/_output/
+tests/_support/UnitTester.php
+tests/_support/_generated/

--- a/tests/_data/reporter-fixture/codeception.yml
+++ b/tests/_data/reporter-fixture/codeception.yml
@@ -1,0 +1,10 @@
+namespace: Fixture
+paths:
+    tests: tests
+    output: tests/_output
+    data: tests/_data
+    support: tests/_support
+actor_suffix: Tester
+extensions:
+    enabled:
+        - Codeception\ProgressReporter\ProgressReporter

--- a/tests/_data/reporter-fixture/tests/unit.suite.yml
+++ b/tests/_data/reporter-fixture/tests/unit.suite.yml
@@ -1,0 +1,1 @@
+actor: UnitTester

--- a/tests/_data/reporter-fixture/tests/unit/SampleTest.php
+++ b/tests/_data/reporter-fixture/tests/unit/SampleTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fixture\Unit;
+
+use Codeception\Test\Unit;
+
+final class SampleTest extends Unit
+{
+    public function testPass(): void
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testFail(): void
+    {
+        $this->assertSame(1, 2, 'intentional failure');
+    }
+
+    public function testError(): void
+    {
+        throw new \RuntimeException('intentional error');
+    }
+}

--- a/tests/unit/ReporterOutputTest.php
+++ b/tests/unit/ReporterOutputTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codeception\ProgressReporter\Tests\Unit;
+
+use Codeception\Test\Unit;
+
+/**
+ * End-to-end test: runs Codeception against a fixture suite (with one passing,
+ * one failing and one erroring test) through the ProgressReporter extension and
+ * asserts the produced console output.
+ */
+final class ReporterOutputTest extends Unit
+{
+    private const FIXTURE = __DIR__ . '/../_data/reporter-fixture';
+
+    private static string $output;
+
+    public static function setUpBeforeClass(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $codecept = $root . '/vendor/bin/codecept';
+        $php = escapeshellarg(PHP_BINARY);
+        $config = escapeshellarg(self::FIXTURE);
+
+        $prefix = $php . ' -d register_argc_argv=On -d memory_limit=512M ' . escapeshellarg($codecept);
+
+        // Make sure the fixture actor classes exist, then run it.
+        exec($prefix . ' build -c ' . $config . ' 2>&1');
+        exec($prefix . ' run -c ' . $config . ' --no-colors 2>&1', $lines);
+
+        // Strip any residual ANSI escape sequences so assertions are stable.
+        self::$output = preg_replace('/\x1b\[[0-9;]*[a-zA-Z]/', '', implode("\n", $lines)) ?? '';
+    }
+
+    public function testShowsProgressBarCounters(): void
+    {
+        $this->assertStringContainsString('Success: 1', self::$output);
+        $this->assertStringContainsString('Errors: 1', self::$output);
+        $this->assertStringContainsString('Fails: 1', self::$output);
+    }
+
+    public function testShowsCurrentSuiteName(): void
+    {
+        $this->assertStringContainsString('Current suite: Fixture.unit', self::$output);
+    }
+
+    public function testPrintsFailureDetails(): void
+    {
+        $this->assertStringContainsString('intentional failure', self::$output);
+        $this->assertStringContainsString('Failed asserting that 2 is identical to 1', self::$output);
+    }
+
+    public function testPrintsErrorDetails(): void
+    {
+        $this->assertStringContainsString('intentional error', self::$output);
+        $this->assertStringContainsString('RuntimeException', self::$output);
+    }
+
+    public function testPrintsResultFooter(): void
+    {
+        $this->assertStringContainsString('Tests: 3, Assertions: 1, Errors: 1, Failures: 1', self::$output);
+    }
+}


### PR DESCRIPTION
## Background

The existing "e2e" coverage was 200 empty stub tests that only make the reporter *draw* a bar — nothing asserted the output was correct. While adding real validation, I found a **bug**.

## Bug: failed runs showed no error details on Codeception 5

- In Codeception 5, `TEST_FAIL_PRINT` is defined and subscribed to, but **never dispatched**. The old `printFailed()` handler was dead code.
- Failures are now rendered at the end of the run by the built-in `Console` via `RESULT_PRINT_AFTER` → `afterResult()`.
- Because this extension silences the built-in Console (to show only the progress bar), failed runs printed the counters but **no error/failure details, stack traces, or footer**.

### Fix
Subscribe to `RESULT_PRINT_AFTER` and delegate to `Console::afterResult()`, which prints the full defect list + footer. No duplication: the default Console isn't subscribed when the run is silenced.

**Before** (failing run): counters only.
**After**: counters *and* the full error/failure report:
```
There was 1 error:
1) SampleTest: Error ... [RuntimeException] intentional error
There was 1 failure:
1) SampleTest: Fail ... Failed asserting that 2 is identical to 1.
ERRORS!
Tests: 3, Assertions: 1, Errors: 1, Failures: 1.
```

## New e2e test

`tests/unit/ReporterOutputTest.php` runs Codeception against a small fixture suite (`tests/_data/reporter-fixture`) with one passing, one failing and one erroring test, captures the output and asserts:
- progress-bar counters (`Success: 1`, `Errors: 1`, `Fails: 1`)
- current suite name
- failure details (`Failed asserting that 2 is identical to 1`)
- error details (`RuntimeException`, `intentional error`)
- result footer (`Tests: 3, Assertions: 1, Errors: 1, Failures: 1`)

Generated fixture artifacts (actor, `_generated`, `_output`) are gitignored; the test rebuilds them.

## Verification
- Full suite green (210 tests).
- PHPStan level 6 clean.