### PR TITLE
Allow symfony/console ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   "require": {
     "php": ">=8.1",
     "codeception/codeception": "^5.0",
-    "symfony/console": "^6.0 || ^7.0"
+    "symfony/console": "^6.0 || ^7.0 || ^8.0"
   },
   "require-dev": {
     "codeception/module-asserts": "^3.0",


### PR DESCRIPTION
Adds `^8.0` to the `symfony/console` constraint. Fixes #27.